### PR TITLE
open pdf in using a split mode rather than in a new tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^0.14.0",
-    "@jupyterlab/apputils": "^0.14.0",
     "@jupyterlab/coreutils": "^1.0.1",
     "@jupyterlab/docmanager": "^0.14.0",
     "@jupyterlab/docregistry": "^0.14.0",

--- a/src/latex.ts
+++ b/src/latex.ts
@@ -108,7 +108,7 @@ function activateLatexPlugin(app: JupyterLab, manager: IDocumentManager, editorT
     const findOpenOrRevealPDF = () => {
       let pdfWidget = manager.findWidget(pdfFilePath);
       if (!pdfWidget) {
-        pdfWidget = manager.openOrReveal(pdfFilePath);
+        pdfWidget = manager.openOrReveal(pdfFilePath, undefined, undefined, {'mode': 'split-right'});
       }
       pdfContext = manager.contextForWidget(pdfWidget);
       pdfContext.disposed.connect(cleanupPreviews);


### PR DESCRIPTION
This is dependent upon https://github.com/jupyterlab/jupyterlab/pull/3571.