### PR TITLE
No mimerender extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "latex"
   ],
   "jupyterlab": {
-    "extension": "lib/latex",
-    "mimeExtension": "lib/pdf"
+    "extension": "lib/index.js"
   },
   "scripts": {
     "build": "tsc",
@@ -31,7 +30,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^0.14.0",
-    "@jupyterlab/apputils": "^0.14.0",
+    "@jupyterlab/apputils": "^0.14.1",
     "@jupyterlab/coreutils": "^1.0.1",
     "@jupyterlab/docmanager": "^0.14.0",
     "@jupyterlab/docregistry": "^0.14.0",
@@ -46,10 +45,10 @@
   },
   "devDependencies": {
     "@types/pdfjs-dist": "^0.1.0",
-    "rimraf": "^2.5.2",
-    "typescript": "~2.4.1",
     "@types/react": "~16.0.19",
-    "@types/react-dom": "~16.0.2"
+    "@types/react-dom": "~16.0.2",
+    "rimraf": "^2.5.2",
+    "typescript": "~2.4.1"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ function activateLatexPlugin(app: JupyterLab, manager: IDocumentManager, editorT
     const findOpenOrRevealPDF = () => {
       let pdfWidget = manager.findWidget(pdfFilePath);
       if (!pdfWidget) {
-        pdfWidget = manager.openOrReveal(pdfFilePath);
+        pdfWidget = manager.openOrReveal(pdfFilePath, 'PDFJS');
       }
       pdfContext = manager.contextForWidget(pdfWidget);
       pdfContext.disposed.connect(cleanupPreviews);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,10 @@ import {
 } from '@jupyterlab/application';
 
 import {
+  InstanceTracker
+} from '@jupyterlab/apputils';
+
+import {
   IStateDB, PathExt, URLExt
 } from '@jupyterlab/coreutils';
 
@@ -33,6 +37,10 @@ import {
   ErrorPanel
 } from './error';
 
+import {
+  PDFJSViewer, PDFJSViewerFactory
+} from './pdf';
+
 import '../style/index.css';
 
 namespace CommandIDs {
@@ -57,7 +65,8 @@ const latexPlugin: JupyterLabPlugin<void> = {
  *
  * @returns a Promise resolved with the JSON response.
  */
-export function latexRequest(url: string, settings: ServerConnection.ISettings): Promise<any> {
+export
+function latexRequest(url: string, settings: ServerConnection.ISettings): Promise<any> {
   let fullUrl = URLExt.join(settings.baseUrl, 'latex', url);
 
   return ServerConnection.makeRequest(fullUrl, {}, settings).then(response => {
@@ -219,7 +228,66 @@ function activateLatexPlugin(app: JupyterLab, manager: IDocumentManager, editorT
   return;
 }
 
-export default latexPlugin;
+/**
+ * The list of file types for pdfs.
+ */
+const FILE_TYPES = [
+  'PDF'
+];
+
+/**
+ * The name of the factory that creates pdf widgets.
+ */
+const FACTORY = 'PDFJS';
+
+/**
+ * The pdf file handler extension.
+ */
+const pdfjsPlugin: JupyterLabPlugin<void> = {
+  activate: activatePDFJS,
+  id: '@jupyterlab/pdfjs-extension:plugin',
+  requires: [ ILayoutRestorer ],
+  autoStart: true
+};
+
+function activatePDFJS(app: JupyterLab, restorer: ILayoutRestorer): void {
+  const namespace = 'pdfjs-widget';
+  const factory = new PDFJSViewerFactory({
+    name: FACTORY,
+    modelName: 'base64',
+    fileTypes: FILE_TYPES,
+    readOnly: true
+  });
+  const tracker = new InstanceTracker<PDFJSViewer>({ namespace });
+
+  // Handle state restoration.
+  restorer.restore(tracker, {
+    command: 'docmanager:open',
+    args: widget => ({ path: widget.context.path, factory: FACTORY }),
+    name: widget => widget.context.path
+  });
+
+  app.docRegistry.addWidgetFactory(factory);
+
+  factory.widgetCreated.connect((sender, widget) => {
+    // Notify the instance tracker if restore data needs to update.
+    widget.context.pathChanged.connect(() => { tracker.save(widget); });
+    tracker.add(widget);
+
+    const types = app.docRegistry.getFileTypesForPath(widget.context.path);
+
+    if (types.length > 0) {
+      widget.title.iconClass = types[0].iconClass;
+      widget.title.iconLabel = types[0].iconLabel;
+    }
+  });
+}
+
+/**
+ * Export the plugins as default.
+ */
+const plugins: JupyterLabPlugin<any>[] = [ latexPlugin, pdfjsPlugin ];
+export default plugins;
 
 /**
  * A namespace for private module data.

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -2,6 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  PromiseDelegate
+} from '@phosphor/coreutils';
+
+import {
   Message
 } from '@phosphor/messaging';
 
@@ -10,8 +14,12 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  IRenderMime
-} from '@jupyterlab/rendermime-interfaces';
+  PathExt
+} from '@jupyterlab/coreutils';
+
+import {
+  ABCWidgetFactory, DocumentRegistry
+} from '@jupyterlab/docregistry';
 
 import 'pdfjs-dist/webpack';
 import 'pdfjs-dist/web/pdf_viewer';
@@ -48,20 +56,72 @@ declare const PDFJS: any;
  * A class for rendering a PDF document.
  */
 export
-class RenderedPDF extends Widget implements IRenderMime.IRenderer {
-  constructor() {
+class PDFJSViewer extends Widget implements DocumentRegistry.IReadyWidget {
+  constructor(context: DocumentRegistry.Context) {
     super({ node: Private.createNode() });
+    this.context = context;
     this._pdfViewer = new PDFJS.PDFViewer({
         container: this.node,
     });
+
+    this._onTitleChanged();
+    context.pathChanged.connect(this._onTitleChanged, this);
+
+    context.ready.then(() => {
+      if (this.isDisposed) {
+        return;
+      }
+      this._render().then(() => {
+        this._ready.resolve(void 0);
+      });
+      context.model.contentChanged.connect(this.update, this);
+      context.fileChanged.connect(this.update, this);
+    });
+  }
+
+  /**
+   * The pdfjs widget's context.
+   */
+  readonly context: DocumentRegistry.Context;
+
+  /**
+   * A promise that resolves when the pdf viewer is ready.
+   */
+  get ready(): Promise<void> {
+    return this._ready.promise;
+  }
+
+  /**
+   * Whether the widget has been disposed.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * Dispose of the resources held by the pdf widget.
+   */
+  dispose() {
+    this._isDisposed = true;
+    try {
+      URL.revokeObjectURL(this._objectUrl);
+    } catch (error) { /* no-op */ }
+    super.dispose();
+  }
+
+  /**
+   * Handle a change to the title.
+   */
+  private _onTitleChanged(): void {
+    this.title.label = PathExt.basename(this.context.localPath);
   }
 
   /**
    * Render PDF into this widget's node.
    */
-  renderModel(model: IRenderMime.IMimeModel): Promise<void> {
+  private _render(): Promise<void> {
     return new Promise<void>(resolve => {
-      let data = model.data[MIME_TYPE] as string;
+      let data = this.context.model.toString();
       // If there is no data, do nothing.
       if (!data) {
         resolve (void 0);
@@ -109,16 +169,6 @@ class RenderedPDF extends Widget implements IRenderMime.IRenderer {
   }
 
   /**
-   * Dispose of the resources held by the pdf widget.
-   */
-  dispose() {
-    try {
-      URL.revokeObjectURL(this._objectUrl);
-    } catch (error) { /* no-op */ }
-    super.dispose();
-  }
-
-  /**
    * Handle DOM events for the widget.
    */
   handleEvent(event: Event): void {
@@ -158,6 +208,16 @@ class RenderedPDF extends Widget implements IRenderMime.IRenderer {
   }
 
   /**
+   * Handle `update-request` messages for the widget.
+   */
+  protected onUpdateRequest(msg: Message): void {
+    if (this.isDisposed || !this.context.isReady) {
+      return;
+    }
+    this._render();
+  }
+
+  /**
    * Fit the PDF to the widget width.
    */
   private _resize(): void {
@@ -166,41 +226,25 @@ class RenderedPDF extends Widget implements IRenderMime.IRenderer {
     }
   }
 
+  private _ready = new PromiseDelegate<void>();
+  private _isDisposed = false;
   private _objectUrl = '';
   private _pdfViewer: any;
   private _pdfDocument: any;
 }
 
-
 /**
- * A mime renderer factory for PDF data.
+ * A widget factory for images.
  */
 export
-const rendererFactory: IRenderMime.IRendererFactory = {
-  safe: false,
-  mimeTypes: [MIME_TYPE],
-  createRenderer: options => new RenderedPDF()
-};
-
-
-const extensions: IRenderMime.IExtension | IRenderMime.IExtension[] = [
-  {
-    id: '@jupyterlab/pdfjs-extension:factory',
-    rendererFactory,
-    rank: 0,
-    dataType: 'string',
-    documentWidgetFactoryOptions: {
-      name: 'PDFJS',
-      modelName: 'base64',
-      primaryFileType: 'PDF',
-      fileTypes: ['PDF'],
-      defaultFor: ['PDF']
-    }
+class PDFJSViewerFactory extends ABCWidgetFactory<PDFJSViewer, DocumentRegistry.IModel> {
+  /**
+   * Create a new widget given a context.
+   */
+  protected createNewWidget(context: DocumentRegistry.IContext<DocumentRegistry.IModel>): PDFJSViewer {
+    return new PDFJSViewer(context);
   }
-];
-
-export default extensions;
-
+}
 
 /**
  * A namespace for PDF widget private data.

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -92,17 +92,9 @@ class PDFJSViewer extends Widget implements DocumentRegistry.IReadyWidget {
   }
 
   /**
-   * Whether the widget has been disposed.
-   */
-  get isDisposed(): boolean {
-    return this._isDisposed;
-  }
-
-  /**
    * Dispose of the resources held by the pdf widget.
    */
   dispose() {
-    this._isDisposed = true;
     try {
       URL.revokeObjectURL(this._objectUrl);
     } catch (error) { /* no-op */ }
@@ -227,7 +219,6 @@ class PDFJSViewer extends Widget implements DocumentRegistry.IReadyWidget {
   }
 
   private _ready = new PromiseDelegate<void>();
-  private _isDisposed = false;
   private _objectUrl = '';
   private _pdfViewer: any;
   private _pdfDocument: any;


### PR DESCRIPTION
Now, PDFJS is not a mimerender extension, but a full plugin.

This required a bit of refactoring, but now it is compatible with the current pdf viewer and mimerender system.